### PR TITLE
fix: pin Windows asset selection to x64, exclude arm64 (OrcaSlicer, Logi Tune)

### DIFF
--- a/automatic/logi-tune/update.ps1
+++ b/automatic/logi-tune/update.ps1
@@ -28,8 +28,12 @@ function GetResultInformation([string]$Url32) {
 function global:au_GetLatest {
   $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
+  # Logitech offers both a standard (x64) and an "arm64" Windows installer on
+  # this page. Neither the '\.exe' match nor -First 1 alone qualify by arch,
+  # so the previous selection depended on DOM order and could silently pick
+  # LogiTuneInstall-arm64.exe instead of LogiTuneInstall.exe (x64).
   $re = '\.exe'
-  $Url32 = $download_page.Links | Where-Object { $_.href -match $re } | Select-Object -First 1 -ExpandProperty href
+  $Url32 = $download_page.Links | Where-Object { $_.href -match $re -and $_.href -notmatch '(?i)arm64' } | Select-Object -First 1 -ExpandProperty href
 
   Update-OnETagChanged -execUrl $Url32 -OnETagChanged { GetResultInformation $Url32 } -OnUpdated { @{ Url32 = $Url32 } }
 }

--- a/automatic/orcaslicer/update.ps1
+++ b/automatic/orcaslicer/update.ps1
@@ -6,7 +6,10 @@ Import-Module "../../scripts/au_extensions.psm1"
 $release = Get-GitHubRelease OrcaSlicer OrcaSlicer
 
 function global:au_GetLatest {
-  $Url32 = $release.assets | ? {$_.name -match 'Windows' } | ? { $_.name.endswith('_portable.zip') } | Select-Object -First 1 -ExpandProperty browser_download_url
+  # OrcaSlicer publishes both arm64 and x64 Windows portable zips; without an
+  # explicit arch filter '-First 1' can silently pick the arm64 asset
+  # depending on GitHub's asset ordering (breaks on x64 machines).
+  $Url32 = $release.assets | ? {$_.name -match 'Windows'} | ? {$_.name -match 'x64'} | ? {$_.name.endswith('_portable.zip')} | Select-Object -First 1 -ExpandProperty browser_download_url
 
   $version = $release.tag_name.Trim('v')
   $ChecksumType = 'sha256'

--- a/automatic/orcaslicer/update.ps1
+++ b/automatic/orcaslicer/update.ps1
@@ -9,7 +9,7 @@ function global:au_GetLatest {
   # OrcaSlicer publishes both arm64 and x64 Windows portable zips; without an
   # explicit arch filter '-First 1' can silently pick the arm64 asset
   # depending on GitHub's asset ordering (breaks on x64 machines).
-  $Url32 = $release.assets | ? {$_.name -match 'Windows'} | ? {$_.name -match 'x64'} | ? {$_.name.endswith('_portable.zip')} | Select-Object -First 1 -ExpandProperty browser_download_url
+  $Url32 = $release.assets | ? { $_.name -match 'Windows' -and $_.name -match 'x64' -and $_.name -like '*_portable.zip' } | Select-Object -First 1 -ExpandProperty browser_download_url
 
   $version = $release.tag_name.Trim('v')
   $ChecksumType = 'sha256'


### PR DESCRIPTION
## Root cause

`automatic/orcaslicer/update.ps1` (`au_GetLatest`) picked the update package's
Windows download URL like this:

```powershell
$Url32 = $release.assets | ? {$_.name -match 'Windows'} | ? {$_.name.endswith('_portable.zip')} | Select-Object -First 1 -ExpandProperty browser_download_url
```

The upstream OrcaSlicer release (v2.4.2) ships **both**
`OrcaSlicer_Windows_V2.4.2_arm64_portable.zip` and
`OrcaSlicer_Windows_V2.4.2_x64_portable.zip`. The filter matches both, and
`-First 1` takes whichever GitHub lists first in `release.assets` — currently
**arm64**. Users on x64 Windows installing/updating the package get an
executable "that cannot be executed". Same class of bug (unqualified
`-First 1` over an asset/link list containing both arch variants) also hit
`automatic/logi-tune/update.ps1`, which resolves its installer from a vendor
download page instead of a GitHub release.

## Audit

I went through every `automatic/*/update.ps1` looking for the same pattern:
an asset/link selection that ends in `-First 1` (or `select -First 1`) over
a set of Windows/`.exe`/`.zip` candidates **without an arch qualifier**
(x64/win64/x86_64/amd64 vs arm64). For every hit I checked the live upstream
release/page for whether an arm64 Windows build actually exists alongside
x64.

| Package | Selection pattern | Upstream arm64 present? | Status |
|---|---|---|---|
| `automatic/bambu-farm-manager-client` | `$html.Links` by role/`\.exe$`, `-First 1` | Bambu family — out of scope for this PR (separate task) | not touched |
| `automatic/bambu-farm-manager-server` | `$html.Links` by role/`\.exe$`, `-First 1` | Bambu family — out of scope for this PR (separate task) | not touched |
| `automatic/bambuconnect` | regex over page HTML, already filters `win32-x64` explicitly | Bambu family — out of scope for this PR (separate task); also already arch-qualified | not touched |
| `automatic/bambustudio` | `$release.assets` match `Bambu_Studio_`/`.exe`, `-First 1`, **no arch qualifier** | Checked `bambulab/BambuStudio` latest release (`v02.07.01.62`): only one Windows asset (`Bambu_Studio_win-v...exe`), no arm64 today → **not currently broken**, but same latent pattern as OrcaSlicer. Bambu family — out of scope for this PR (separate task) | not touched |
| `automatic/dellbiosprovider` | no asset selection (`ChecksumFor none`, version scraped from PowerShell Gallery page) | n/a | ok |
| `automatic/logi-tune` | `$download_page.Links` match `\.exe`, `-First 1`, **no arch qualifier** | Checked the vendor page: two separate download buttons, `LogiTuneInstall.exe` (x64) and `LogiTuneInstall-arm64.exe` (arm64) both present | **confirmed → fixed** |
| `automatic/microsoft-sql-server-migration-assistant-for-access` | `$download_page.Links`, but already arch-qualified (`x86.msi` vs "not x86.msi" for 64-bit) | n/a (no arm64 build exists for this legacy MS tool) | ok, already arch-aware |
| `automatic/orcaslicer` | `$release.assets` match `Windows`/`_portable.zip`, `-First 1`, **no arch qualifier** | Checked `SoftFever/OrcaSlicer` latest release (`v2.4.2`): both `..._arm64_portable.zip` and `..._x64_portable.zip` present, arm64 sorts first | **confirmed → fixed** |
| `automatic/qemu-guest-agent` | Url32/Url64 built from explicit filenames (`qemu-ga-i386.msi` / `qemu-ga-x86_64.msi`), no `-First 1` over ambiguous candidates | n/a | ok |
| `automatic/qemu-virtio-driver` | Url32/Url64 built from explicit filenames (`virtio-win-gt-x86.msi` / `virtio-win-gt-x64.msi`) | n/a | ok |
| `automatic/speedtest-by-ookla` | Url32/Url64 built from explicit filenames (`speedtestbyookla_x86.msi` / `_x64.msi`) | n/a | ok |

## Fixes in this PR

**`automatic/orcaslicer/update.ps1`** — added an explicit `-match 'x64'`
filter alongside the existing `Windows` / `_portable.zip` filters:

```powershell
$Url32 = $release.assets | ? {$_.name -match 'Windows'} | ? {$_.name -match 'x64'} | ? {$_.name.endswith('_portable.zip')} | Select-Object -First 1 -ExpandProperty browser_download_url
```

Verification (no AU run possible from here, reasoned against the real asset
list from `gh api repos/SoftFever/OrcaSlicer/releases/latest`): the four
Windows assets are `OrcaSlicer_Windows_Installer_V2.4.2_arm64.exe`,
`OrcaSlicer_Windows_Installer_V2.4.2_x64.exe`,
`OrcaSlicer_Windows_V2.4.2_arm64_portable.zip`,
`OrcaSlicer_Windows_V2.4.2_x64_portable.zip`. After the three filters
(`Windows`, `x64`, ends with `_portable.zip`) only
`OrcaSlicer_Windows_V2.4.2_x64_portable.zip` remains, regardless of asset
order — the literal string `arm64` never contains `x64` as a substring
(`a-r-m-6-4`, no `x`), so the new filter is a safe, unambiguous exclusion of
the arm64 asset without needing a negative match.

**`automatic/logi-tune/update.ps1`** — the x64 filename carries no arch
token to match against (`LogiTuneInstall.exe`), so the fix excludes the
arm64 link instead of positively matching x64:

```powershell
$Url32 = $download_page.Links | Where-Object { $_.href -match $re -and $_.href -notmatch '(?i)arm64' } | Select-Object -First 1 -ExpandProperty href
```

Verification: fetched the vendor page; the two relevant `.exe` links are
`https://software.vc.logitech.com/downloads/tune/LogiTuneInstall.exe` and
`https://software.vc.logitech.com/downloads/tune/LogiTuneInstall-arm64.exe`.
The `-notmatch '(?i)arm64'` condition removes the second one regardless of
DOM order, leaving only the x64 installer.

## Other observations from the audit (not fixed here, scope discipline)

- `automatic/bambustudio` has the *exact same* unqualified `-First 1`
  pattern as OrcaSlicer and will break the same way the day BambuStudio
  publishes an arm64 Windows asset. Currently safe only because no arm64
  asset exists yet. Recommend a follow-up once the Bambu-family task is
  scoped.
- `_template/update.ps1` (the scaffold used for new packages) contains the
  same unqualified pattern (`$download_page.links | ? href -match $re |
  select -First 1 -expand href`). Not a live package, so nothing breaks
  today, but new packages copied from this template will inherit the same
  latent bug.
- `manual/cyberbrick/update.ps1` looks like a stray copy-paste from
  `bambuconnect`: it scrapes `bambulab.com` for `bambu-connect` download
  links and is titled `"Bambu Connect (Install)"`, which doesn't match a
  CyberBrick package at all. Looks broken/mislabeled, but unrelated to the
  arm64/x64 selection bug and also Bambu-adjacent, so left untouched.
- `deprecated/pkt/update.ps1` has the same generic pattern but lives under
  `deprecated/`, so left alone.

## Review

Not merging — please review before merge (per repo convention: no self-merge
for update-script logic changes).