### PR TITLE
(bambustudio) Pin dependency versions + root-cause analysis for Verification Testing Failed

### DIFF
--- a/automatic/bambustudio/bambustudio.nuspec
+++ b/automatic/bambustudio/bambustudio.nuspec
@@ -38,8 +38,8 @@ To use choco:// protocol URLs, install [(unofficial) choco:// Protocol support](
 ]]></description>
     <releaseNotes>https://github.com/bambulab/BambuStudio/releases/tag/v02.07.01.62</releaseNotes>
     <dependencies>
-      <dependency id="vcredist140" />
-      <dependency id="webview2-runtime" />
+      <dependency id="vcredist140" version="14.0.24215.1" />
+      <dependency id="webview2-runtime" version="109.0.1518.52" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
## Description
Pins explicit minimum versions on the two dependencies of `bambustudio` (`vcredist140`, `webview2-runtime`) instead of leaving them version-less:

- `vcredist140` >= `14.0.24215.1`
- `webview2-runtime` >= `109.0.1518.52`

Both versions were verified to exist on the `community.chocolatey.org` NuGet feed before pinning.

## Motivation and Context

This addresses the recurring **Guideline** finding from `chocolatey-ops` on every validation run of `bambustudio` 2.7.1.62 (16 Jun and 07 Jul 2026):

> Package contains dependencies with no specified version. You should at least specify a minimum version of a dependency. ([CPMR0052](https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0052))

### Important: this PR does NOT fix "Verification Testing Failed"

This was investigated as a separate, dedicated root-cause task (independent of PR #12). Summary of findings, evidence linked below:

- `bambustudio` 2.7.1.62 has failed the **Verification Testing** step of the Chocolatey Package Verifier three times, spanning almost a month:
  - [16 Jun 2026](https://gist.github.com/choco-bot/85a4548d114d6f3fc4197fdd0923536c) — before the `webview2-runtime` dependency existed
  - [24 Jun 2026](https://gist.github.com/choco-bot/2c3bf1698f18dab8d026bb09f22c4bdf) — rerun, same result
  - [07 Jul 2026](https://gist.github.com/choco-bot/b7ef8c3cef9e70cf42383a8ba6274729) — **after** the `webview2-runtime` dependency was added in 9b3cf1d
- All three runs fail with the byte-for-byte identical summary: *"Install failed. Note that the process may have hung... This can also happen when a window pops up and needs to be closed to continue."* Adding the `webview2-runtime` dependency made no difference to the outcome.
- In the 07 Jul run's `Install.txt`, both declared dependencies install and **exit 0** cleanly (`vcredist140-x86`, `vcredist140-x64`, `webview2-runtime` all completed successfully) *before* `bambustudio`'s own installer is even started. So a non-silent bundled dependency installer is ruled out as the cause.
- The installer itself is a real **Nullsoft Install System (NSIS) v3.08** package (confirmed via manifest string in the binary), and `/S` is the textbook-correct silent switch for NSIS — the flag is not the problem.
- In every run, the log simply stops right after `Elevating permissions and running [...\Bambu_Studio_win-...exe" /S]` — no error, no exit code, no further output at all — until the verifier declares the install "hung" and posts a failure.
- Chocolatey's own docs state the Package Verifier ["limits the execution of the install/uninstall commands to 20 minutes each"](https://docs.chocolatey.org/en-us/community-repository/moderation/package-verifier/) on a single, shared VirtualBox test VM.
- That VM shows heavy, inconsistent load: SHA-256 checksumming of the same 427 MB installer took **5 seconds** (16 Jun), **7m28s** (24 Jun), and **14 minutes** (07 Jul) across the three runs — a >150x variance for an operation that normally takes seconds. The BambuStudio installer's own `/S` run then gets ~5–18 more minutes before the 20-minute window is exhausted.
- The currently-**approved** version, `bambustudio` 2.7.1.57, ships an installer of essentially the same size (407.3 MB vs 407.3 MB) — so this isn't a case of a newly oversized package; it's the same size class that has passed before, just apparently not on a busy day.

**Conclusion: this is a Package-Verifier environment/timeout limitation on a resource-constrained shared VM, not a defect in this package.** No code change in this repository can influence the verifier's external 20-minute watchdog — that's enforced from outside the package's own install script.

**Recommended maintainer action (separate from this PR):** leave a comment on the [bambustudio 2.7.1.62 package page](https://community.chocolatey.org/packages/bambustudio/2.7.1.62) addressed to the moderators, per the documented ["How can I bypass the verifier?"](https://docs.chocolatey.org/en-us/community-repository/moderation/package-verifier/#how-can-i-bypass-the-verifier) process, citing the evidence above and requesting either a verifier re-run or a manual bypass/approval.

## How Has this Been Tested?
- `bambustudio.nuspec` validated as well-formed XML.
- Both pinned dependency versions (`vcredist140` 14.0.24215.1, `webview2-runtime` 109.0.1518.52) confirmed to exist via the `community.chocolatey.org` OData feed (`Packages(Id=...,Version=...)`).
- No install/uninstall test was run in the chocolatey test environment for this change, since it only tightens a dependency version range already satisfied by every version currently resolved by choco (`vcredist140` 14.51.36247, `webview2-runtime` 150.0.4078.48 in the latest verifier log) — it cannot change install behavior.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) — fixes the CPMR0052 Guideline finding
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest Contributing Guidelines.
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment (not applicable — see "How Has this Been Tested?").
- [x] The changes only affect a single package (not including meta package).