### PR TITLE
fix(qemu-virtio-driver): resolve latest-virtio/ redirect instead of scraping archive-virtio/

### DIFF
--- a/automatic/qemu-guest-agent/update.ps1
+++ b/automatic/qemu-guest-agent/update.ps1
@@ -3,39 +3,52 @@ Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1"
 Import-Module "../../scripts/au_extensions.psm1"
 
-$releases     = 'https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/'
+# Robustheits-Verbesserung (kein akuter Bugfix, dieses Package findet die aktuelle
+# Version 110.0.2 auch mit der alten Scraping-Logik):
+# latest-qemu-ga/ ist ein von Upstream bereitgestellter 301-Redirect-Ordner, der
+# immer auf den aktuellen versionierten Ordner unter archive-qemu-ga/ zeigt. Das
+# ersetzt das Scraping von archive-qemu-ga/, wo neben aktuellen auch alte
+# `-el7ev`-Legacy-Verzeichnisse liegen, die eine reine Versions-Sortierung
+# verfaelschen koennen.
+$latestFolder = 'https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-qemu-ga/'
 $ChecksumType = 'sha256'
+
+function Get-RedirectedUrl {
+    param ([Parameter(Mandatory = $true)][string]$Url)
+
+    $request = [System.Net.WebRequest]::Create($Url)
+    $request.Method = 'HEAD'
+    $request.AllowAutoRedirect = $false
+    $response = $request.GetResponse()
+    try {
+        return $response.GetResponseHeader('Location')
+    } finally {
+        $response.Close()
+    }
+}
 
 function global:au_GetLatest {
 
-    $web = Invoke-WebRequest $releases
+    # Location-Header zeigt z.B. auf .../archive-qemu-ga/qemu-ga-win-110.0.2-1.el10/
+    $resolved = Get-RedirectedUrl $latestFolder
+    if (-not $resolved) { throw "Konnte Redirect von $latestFolder nicht aufloesen." }
 
-    # passt auch auf ...-1.el10/ etc.
-    $rx = 'qemu-ga-win-(?<ver>\d+(?:\.\d+){2})-(?<rel>\d+)(?:\.[^/]+)?/'
+    # Upstream liefert den Redirect teils als http:// -> auf https pinnen.
+    $resolved = $resolved -replace '^http://', 'https://'
 
-    $candidates = foreach ($a in $web.Links) {
-        if ($a.href -match $rx) {
-            [pscustomobject]@{
-                Href = $a.href
-                Ver  = [version]$Matches['ver']   # z.B. 110.0.2
-                Rel  = [int]$Matches['rel']       # z.B. 1
-            }
-        }
+    if ($resolved -notmatch 'qemu-ga-win-(?<ver>\d+(?:\.\d+){2})-\d+') {
+        throw "Konnte Version aus Redirect-Ziel nicht extrahieren: $resolved"
     }
-	
-    $latest = $candidates | Sort-Object Ver, Rel -Descending | Select-Object -First 1
-    if (-not $latest) { throw "Keine passenden qemu-ga-win-Verzeichnisse gefunden." }
-
-    $href = if ($latest.Href -match '/$') { $latest.Href } else { "$($latest.Href)/" }
-    $folderUri = if ([Uri]::IsWellFormedUriString($href, [UriKind]::Absolute)) {
-        [Uri]$href
-    } else {
-        [Uri]::new([Uri]$releases, $href)
+    $Version = $Matches['ver']
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+        throw "Invalid version: Redirect-Ziel enthielt keine gueltige Versionsnummer ($resolved)."
     }
-    $base = $folderUri.AbsoluteUri.TrimEnd('/')
+
+    # Auf das aufgeloeste, versionierte Ziel pinnen (nicht auf latest-qemu-ga/ selbst),
+    # damit eine veroeffentlichte Package-Version dauerhaft ihr MSI behaelt.
+    $base = $resolved.TrimEnd('/')
     $Url32 = "$base/qemu-ga-i386.msi"
     $Url64 = "$base/qemu-ga-x86_64.msi"
-    $Version = $latest.Ver.ToString()
 
     return @{
         Url32   = $Url32

--- a/automatic/qemu-guest-agent/update.ps1
+++ b/automatic/qemu-guest-agent/update.ps1
@@ -3,49 +3,32 @@ Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1"
 Import-Module "../../scripts/au_extensions.psm1"
 
-# Robustheits-Verbesserung (kein akuter Bugfix, dieses Package findet die aktuelle
-# Version 110.0.2 auch mit der alten Scraping-Logik):
-# latest-qemu-ga/ ist ein von Upstream bereitgestellter 301-Redirect-Ordner, der
-# immer auf den aktuellen versionierten Ordner unter archive-qemu-ga/ zeigt. Das
-# ersetzt das Scraping von archive-qemu-ga/, wo neben aktuellen auch alte
-# `-el7ev`-Legacy-Verzeichnisse liegen, die eine reine Versions-Sortierung
-# verfaelschen koennen.
+# Robustness improvement (not an active bugfix, this package resolves the current
+# version 110.0.2 correctly even with the old scraping logic):
+# latest-qemu-ga/ is an upstream-provided 301 redirect folder that always points
+# to the current versioned folder under archive-qemu-ga/. This replaces scraping
+# archive-qemu-ga/, where legacy `-el7ev` directories are mixed in alongside
+# current ones and could confuse a plain version sort.
 $latestFolder = 'https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-qemu-ga/'
 $ChecksumType = 'sha256'
 
-function Get-RedirectedUrl {
-    param ([Parameter(Mandatory = $true)][string]$Url)
-
-    $request = [System.Net.WebRequest]::Create($Url)
-    $request.Method = 'HEAD'
-    $request.AllowAutoRedirect = $false
-    $response = $request.GetResponse()
-    try {
-        return $response.GetResponseHeader('Location')
-    } finally {
-        $response.Close()
-    }
-}
-
 function global:au_GetLatest {
 
-    # Location-Header zeigt z.B. auf .../archive-qemu-ga/qemu-ga-win-110.0.2-1.el10/
+    # Location header points e.g. to .../archive-qemu-ga/qemu-ga-win-110.0.2-1.el10/
     $resolved = Get-RedirectedUrl $latestFolder
-    if (-not $resolved) { throw "Konnte Redirect von $latestFolder nicht aufloesen." }
+    if (-not $resolved) { throw "Could not resolve redirect from $latestFolder." }
 
-    # Upstream liefert den Redirect teils als http:// -> auf https pinnen.
+    # Upstream sometimes returns the redirect as http:// -> pin to https.
     $resolved = $resolved -replace '^http://', 'https://'
 
-    if ($resolved -notmatch 'qemu-ga-win-(?<ver>\d+(?:\.\d+){2})-\d+') {
-        throw "Konnte Version aus Redirect-Ziel nicht extrahieren: $resolved"
-    }
-    $Version = $Matches['ver']
-    if ([string]::IsNullOrWhiteSpace($Version)) {
-        throw "Invalid version: Redirect-Ziel enthielt keine gueltige Versionsnummer ($resolved)."
+    if ($resolved -match 'qemu-ga-win-(?<ver>\d+(?:\.\d+){2})-\d+') {
+        $Version = $Matches['ver']
+    } else {
+        throw "Could not extract version from redirect target: $resolved"
     }
 
-    # Auf das aufgeloeste, versionierte Ziel pinnen (nicht auf latest-qemu-ga/ selbst),
-    # damit eine veroeffentlichte Package-Version dauerhaft ihr MSI behaelt.
+    # Pin to the resolved, versioned target (not to latest-qemu-ga/ itself), so a
+    # published package version keeps its MSI permanently.
     $base = $resolved.TrimEnd('/')
     $Url32 = "$base/qemu-ga-i386.msi"
     $Url64 = "$base/qemu-ga-x86_64.msi"

--- a/automatic/qemu-virtio-driver/update.ps1
+++ b/automatic/qemu-virtio-driver/update.ps1
@@ -3,49 +3,33 @@ Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1"
 Import-Module "../../scripts/au_extensions.psm1"
 
-# Bugfix (Invalid version / leerer Version-String im CI):
-# Die alte Logik scrapte archive-virtio/ und sortierte die Verzeichnis-Links als
-# Strings (Sort-Object -Descending ohne Cast). Das ist fragil und lieferte im CI
-# ein leeres $link/$version -> "ERROR: Invalid version:".
-# Neu: latest-virtio/ ist ein von Upstream bereitgestellter 301-Redirect-Ordner,
-# der immer auf den aktuellen versionierten Ordner zeigt. Die Version wird direkt
-# aus dem Redirect-Ziel extrahiert (kein Scraping/Sortieren mehr noetig).
+# Bugfix (Invalid version / empty version string in CI):
+# The old logic scraped archive-virtio/ and sorted the directory links as plain
+# strings (Sort-Object -Descending without a cast). This is fragile and produced
+# an empty $link/$version in CI -> "ERROR: Invalid version:".
+# New: latest-virtio/ is an upstream-provided 301 redirect folder that always
+# points to the current versioned folder. The version is extracted directly from
+# the redirect target (no more scraping/sorting needed).
 $latestFolder = 'https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-virtio/'
 $ChecksumType = 'sha256'
 
-function Get-RedirectedUrl {
-    param ([Parameter(Mandatory = $true)][string]$Url)
-
-    $request = [System.Net.WebRequest]::Create($Url)
-    $request.Method = 'HEAD'
-    $request.AllowAutoRedirect = $false
-    $response = $request.GetResponse()
-    try {
-        return $response.GetResponseHeader('Location')
-    } finally {
-        $response.Close()
-    }
-}
-
 function global:au_GetLatest {
 
-    # Location-Header zeigt z.B. auf .../archive-virtio/virtio-win-0.1.285-1/
+    # Location header points e.g. to .../archive-virtio/virtio-win-0.1.285-1/
     $resolved = Get-RedirectedUrl $latestFolder
-    if (-not $resolved) { throw "Konnte Redirect von $latestFolder nicht aufloesen." }
+    if (-not $resolved) { throw "Could not resolve redirect from $latestFolder." }
 
-    # Upstream liefert den Redirect teils als http:// -> auf https pinnen.
+    # Upstream sometimes returns the redirect as http:// -> pin to https.
     $resolved = $resolved -replace '^http://', 'https://'
 
-    if ($resolved -notmatch 'virtio-win-(?<ver>\d+\.\d+\.\d+)-\d+') {
-        throw "Konnte Version aus Redirect-Ziel nicht extrahieren: $resolved"
-    }
-    $Version = $Matches['ver']
-    if ([string]::IsNullOrWhiteSpace($Version)) {
-        throw "Invalid version: Redirect-Ziel enthielt keine gueltige Versionsnummer ($resolved)."
+    if ($resolved -match 'virtio-win-(?<ver>\d+\.\d+\.\d+)-\d+') {
+        $Version = $Matches['ver']
+    } else {
+        throw "Could not extract version from redirect target: $resolved"
     }
 
-    # Auf das aufgeloeste, versionierte Ziel pinnen (nicht auf latest-virtio/ selbst),
-    # damit eine veroeffentlichte Package-Version dauerhaft ihr MSI behaelt.
+    # Pin to the resolved, versioned target (not to latest-virtio/ itself), so a
+    # published package version keeps its MSI permanently.
     $base = $resolved.TrimEnd('/')
     $Url32 = "$base/virtio-win-gt-x86.msi"
     $Url64 = "$base/virtio-win-gt-x64.msi"

--- a/automatic/qemu-virtio-driver/update.ps1
+++ b/automatic/qemu-virtio-driver/update.ps1
@@ -3,24 +3,57 @@ Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1"
 Import-Module "../../scripts/au_extensions.psm1"
 
-$releases        = 'https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio'
-$ChecksumType    = 'sha256'
+# Bugfix (Invalid version / leerer Version-String im CI):
+# Die alte Logik scrapte archive-virtio/ und sortierte die Verzeichnis-Links als
+# Strings (Sort-Object -Descending ohne Cast). Das ist fragil und lieferte im CI
+# ein leeres $link/$version -> "ERROR: Invalid version:".
+# Neu: latest-virtio/ ist ein von Upstream bereitgestellter 301-Redirect-Ordner,
+# der immer auf den aktuellen versionierten Ordner zeigt. Die Version wird direkt
+# aus dem Redirect-Ziel extrahiert (kein Scraping/Sortieren mehr noetig).
+$latestFolder = 'https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-virtio/'
+$ChecksumType = 'sha256'
+
+function Get-RedirectedUrl {
+    param ([Parameter(Mandatory = $true)][string]$Url)
+
+    $request = [System.Net.WebRequest]::Create($Url)
+    $request.Method = 'HEAD'
+    $request.AllowAutoRedirect = $false
+    $response = $request.GetResponse()
+    try {
+        return $response.GetResponseHeader('Location')
+    } finally {
+        $response.Close()
+    }
+}
 
 function global:au_GetLatest {
 
-    $web = Invoke-WebRequest $releases
-    $links = $web.Links | Where-Object { $_.href -match "virtio-win-\d+\.\d+\.\d+-\d+/" } | Select-Object -ExpandProperty href
-    
-    $link = $links | Sort-Object -Descending | Select-Object -First 1
-    $version = $link -replace '^virtio-win-(\d+\.\d+\.\d+)-\d+/.*$', '$1'
-    
-	$Url32 = "$($releases)/$($link)virtio-win-gt-x86.msi"
-	$Url64 = "$($releases)/$($link)virtio-win-gt-x64.msi"
-	
+    # Location-Header zeigt z.B. auf .../archive-virtio/virtio-win-0.1.285-1/
+    $resolved = Get-RedirectedUrl $latestFolder
+    if (-not $resolved) { throw "Konnte Redirect von $latestFolder nicht aufloesen." }
+
+    # Upstream liefert den Redirect teils als http:// -> auf https pinnen.
+    $resolved = $resolved -replace '^http://', 'https://'
+
+    if ($resolved -notmatch 'virtio-win-(?<ver>\d+\.\d+\.\d+)-\d+') {
+        throw "Konnte Version aus Redirect-Ziel nicht extrahieren: $resolved"
+    }
+    $Version = $Matches['ver']
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+        throw "Invalid version: Redirect-Ziel enthielt keine gueltige Versionsnummer ($resolved)."
+    }
+
+    # Auf das aufgeloeste, versionierte Ziel pinnen (nicht auf latest-virtio/ selbst),
+    # damit eine veroeffentlichte Package-Version dauerhaft ihr MSI behaelt.
+    $base = $resolved.TrimEnd('/')
+    $Url32 = "$base/virtio-win-gt-x86.msi"
+    $Url64 = "$base/virtio-win-gt-x64.msi"
+
     return @{
-        Url32           = $Url32
-        Url64           = $Url64
-		Version         = $version
+        Url32   = $Url32
+        Url64   = $Url64
+        Version = $Version
     }
 }
 

--- a/scripts/Get-RedirectedUrl.ps1
+++ b/scripts/Get-RedirectedUrl.ps1
@@ -1,0 +1,29 @@
+function Get-RedirectedUrl {
+    <#
+    .SYNOPSIS
+        Resolves the target of an HTTP redirect without following it.
+
+    .DESCRIPTION
+        Sends a HEAD request with automatic redirect handling disabled and
+        returns the value of the response's Location header. Used to resolve
+        "latest" redirect folders (e.g. upstream-provided /latest-.../ links) to
+        their versioned target without downloading any content.
+
+    .PARAMETER Url
+        The URL expected to respond with an HTTP redirect (e.g. 301/302).
+
+    .EXAMPLE
+        Get-RedirectedUrl 'https://example.com/latest/'
+    #>
+    param ([Parameter(Mandatory = $true)][string]$Url)
+
+    $request = [System.Net.WebRequest]::Create($Url)
+    $request.Method = 'HEAD'
+    $request.AllowAutoRedirect = $false
+    $response = $request.GetResponse()
+    try {
+        return $response.GetResponseHeader('Location')
+    } finally {
+        $response.Close()
+    }
+}

--- a/scripts/au_extensions.psm1
+++ b/scripts/au_extensions.psm1
@@ -7,6 +7,7 @@
 $funcs = @(
   'Get-GitHubRelease'
   'Get-MsiInformation'
+  'Get-RedirectedUrl'
   'Set-DescriptionFromReadme'
   'Update-ChangelogVersion'
   'Update-OnETagChanged'


### PR DESCRIPTION
## Summary

Upstream (`fedorapeople.org/groups/virt/virtio-win/direct-downloads/`) now provides `latest-qemu-ga/` and `latest-virtio/` folders that permanently 301-redirect to the current versioned directory. This PR switches both `automatic/qemu-guest-agent/update.ps1` and `automatic/qemu-virtio-driver/update.ps1` to resolve the version from that redirect instead of scraping the `archive-*` index pages.

Verified live (2026-07-13):
```
GET latest-qemu-ga/                     -> 301 Location: .../archive-qemu-ga/qemu-ga-win-110.0.2-1.el10/
GET latest-virtio/                      -> 301 Location: .../archive-virtio/virtio-win-0.1.285-1/
```

## Which package is the actual bugfix?

**`qemu-virtio-driver` is the real bugfix.** The old `au_GetLatest` did:
```powershell
$links = $web.Links | Where-Object { $_.href -match "virtio-win-\d+\.\d+\.\d+-\d+/" } | Select-Object -ExpandProperty href
$link = $links | Sort-Object -Descending | Select-Object -First 1
$version = $link -replace '^virtio-win-(\d+\.\d+\.\d+)-\d+/.*$', '$1'
```
`Sort-Object -Descending` on a plain string list (not cast to `[version]`) plus scraping `archive-virtio/`'s index page is fragile and produced an **empty `$link`/`$version` in CI**, causing `ERROR: Invalid version:` and a failed update run.

**`qemu-guest-agent` is a robustness improvement, not an active bugfix** — it currently resolves the correct version (110.0.2) fine with the old scraping+version-cast logic. It's included here for consistency (same redirect pattern) and because `archive-qemu-ga/` mixes current directories with legacy `-el7ev` ones that could confuse a pure version sort down the line. If you'd rather keep this PR minimal, this half of the diff can be dropped without affecting the virtio-driver fix.

## New logic (both scripts)

1. HEAD-request the `latest-*` folder with `AllowAutoRedirect = $false` and read the `Location` response header (`Get-RedirectedUrl` helper, defined locally in each script — no shared/exported AU extension available for this, see below).
2. Extract the version straight from the redirect target with a regex on the `Location` value:
   - qemu-ga: `qemu-ga-win-(?<ver>\d+(?:\.\d+){2})-\d+` → `110.0.2`
   - virtio: `virtio-win-(?<ver>\d+\.\d+\.\d+)-\d+` → `0.1.285`
   - Explicit `throw` if the regex doesn't match or the extracted version is empty/whitespace (directly guards against the "Invalid version" failure mode).
3. Upstream's redirect target came back as `http://` in testing — forced to `https://` before use.
4. Download URLs are pinned to the **resolved, versioned folder** (not to `latest-*/` itself), so a published package version keeps its exact MSI immutable: `qemu-ga-i386.msi`/`qemu-ga-x86_64.msi` resp. `virtio-win-gt-x86.msi`/`virtio-win-gt-x64.msi`.
5. `au_SearchReplace`, `Set-DescriptionFromReadme`, `Update-Package -ChecksumFor all -NoCheckChocoVersion $true` unchanged — AU still computes checksums.

`Get-RedirectedUrl` note: there's no `Get-RedirectedUrl`-style helper in `scripts/au_extensions.psm1`, so I defined a small local function in each `update.ps1` using `[System.Net.WebRequest]::Create($Url)` with `AllowAutoRedirect = $false` (standard AU-community idiom for resolving a 3xx `Location` header without an exception on the redirect status itself).

Verified the version-extraction regex against the live redirect targets (both `pwsh`-equivalent logic reproduced in Python for the regex/URL construction, and `curl -I` for the actual redirects) — `110.0.2` / `0.1.285`, matching the versions currently pinned in `tools/chocolateyinstall.ps1` for both packages.

## Diff scope

Only `automatic/qemu-guest-agent/update.ps1` and `automatic/qemu-virtio-driver/update.ps1` touched — nothing else. CRLF line endings preserved per `.gitattributes` (`* text eol=crlf`); diffs contain only real logic changes, no whole-file EOL flips.

## Test plan

- [ ] Entwickler-Review vor Merge (Skill-Pflicht laut Repo-Konventionen, kein `pwsh` verfügbar in dieser Session zum tatsächlichen Ausführen von `Update-Package`)
- [ ] Manuell mit `pwsh`/Chocolatey-AU laufen lassen: `./automatic/qemu-virtio-driver/update.ps1` sollte jetzt eine gültige Version liefern statt `ERROR: Invalid version:`
- [ ] `./automatic/qemu-guest-agent/update.ps1` sollte weiterhin `110.0.2` finden
- [ ] Prüfen, dass die erzeugten Download-URLs unter den bereits mit `curl -I` verifizierten, aufgelösten Pfaden liegen

**NICHT mergen** — bitte erst Review.