### PR TITLE
fix(speedtest-by-ookla): use /latest/ MSI URLs and read version from MSI

### DIFF
--- a/automatic/speedtest-by-ookla/update.ps1
+++ b/automatic/speedtest-by-ookla/update.ps1
@@ -3,26 +3,36 @@ Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1"
 Import-Module "../../scripts/au_extensions.psm1"
 
-$releases        = 'https://www.speedtest.net/de/apps/windows'
-$ChecksumType    = 'sha256'
+$Url32        = 'https://install.speedtest.net/app/windows/latest/speedtestbyookla_x86.msi'
+$Url64        = 'https://install.speedtest.net/app/windows/latest/speedtestbyookla_x64.msi'
+$ChecksumType = 'sha256'
 
 function global:au_GetLatest {
-	$web = Invoke-WebRequest $releases
-	$currentVersion = $web.AllElements | ?{$_.tagname -eq 'SPAN' -and $_.class -eq 'u-note'} | Select-Object -First 1 -Expand InnerText
-	$version = $currentVersion.TrimStart("v")
-	
-	$req = Invoke-WebRequest -Uri $releases
-	$currentVersion = $req.AllElements | ?{$_.tagname -eq 'SPAN' -and $_.class -eq 'u-note'} | Select-Object -First 1 -Expand InnerText
-	$version = $currentVersion.TrimStart("v")
-    
-	$Url32 = "https://install.speedtest.net/app/windows/$($version)/speedtestbyookla_x86.msi"
-	$Url64 = "https://install.speedtest.net/app/windows/$($version)/speedtestbyookla_x64.msi"
-	
-    return @{
-        Url32           = $Url32
-        Url64           = $Url64
-		Version         = $version
-    }
+	# Ookla retired the versioned download path (`/app/windows/<version>/...msi`) -
+	# requests to it now return 403 Forbidden. Only the static `/latest/` path still
+	# works, but it no longer encodes the version in the URL or on the download page.
+	# So the version has to be read from the downloaded MSI's ProductVersion property
+	# instead of being scraped from https://www.speedtest.net/de/apps/windows.
+	$fileName = Split-Path -Leaf $Url64
+	$dest     = "$env:TEMP\$fileName"
+
+	Get-WebFile $Url64 $dest | Out-Null
+	try {
+		$version = (Get-MsiInformation -Path $dest -Property ProductVersion).ProductVersion
+	}
+	finally {
+		Remove-Item $dest -Force -ErrorAction SilentlyContinue
+	}
+
+	if ([string]::IsNullOrWhiteSpace($version)) {
+		throw "Could not determine ProductVersion from $Url64"
+	}
+
+	return @{
+		Url32   = $Url32
+		Url64   = $Url64
+		Version = $version
+	}
 }
 
 function global:au_SearchReplace {

--- a/automatic/speedtest-by-ookla/update.ps1
+++ b/automatic/speedtest-by-ookla/update.ps1
@@ -14,10 +14,10 @@ function global:au_GetLatest {
 	# So the version has to be read from the downloaded MSI's ProductVersion property
 	# instead of being scraped from https://www.speedtest.net/de/apps/windows.
 	$fileName = Split-Path -Leaf $Url64
-	$dest     = "$env:TEMP\$fileName"
+	$dest     = Join-Path $env:TEMP $fileName
 
-	Get-WebFile $Url64 $dest | Out-Null
 	try {
+		Get-WebFile $Url64 $dest | Out-Null
 		$version = (Get-MsiInformation -Path $dest -Property ProductVersion).ProductVersion
 	}
 	finally {


### PR DESCRIPTION
## Problem

AppVeyor build for `speedtest-by-ookla` fails:

```
speedtest-by-ookla ERROR: Can't validate URL ... (403) Forbidden: .../windows/1.15.200/speedtestbyookla_x86.msi
```

Ookla removed the versioned download path (`/app/windows/<version>/speedtestbyookla_x86|x64.msi`) — any request to a versioned path now returns `403 Forbidden`. Confirmed via `curl -I`:

- `https://install.speedtest.net/app/windows/latest/speedtestbyookla_x64.msi` → `200 OK` (56 MB)
- `https://install.speedtest.net/app/windows/latest/speedtestbyookla_x86.msi` → `200 OK` (52 MB)
- Any `/app/windows/<version>/...` path → `403 Forbidden`

Only the static `/latest/` path still works.

## Fix

- `Url32`/`Url64` are now fixed to the static `/latest/` paths instead of being built from a scraped version string.
- Since the `/latest/` URL doesn't encode the version anywhere (not in the URL, and no longer scrapeable from `span.u-note` on `https://www.speedtest.net/de/apps/windows` either — that scrape was the old mechanism and is now unrelated/unreliable for this purpose), the version is read from the downloaded MSI's `ProductVersion` property instead.
- Reused the existing `Get-MsiInformation` helper already exported by `scripts/au_extensions.psm1` (was present but unused by this package) — no new COM/WindowsInstaller code needed. Follows the same "download install, then read version off the artifact" pattern already used by `automatic/bambustudio/update.ps1` and `automatic/logi-tune/update.ps1` (there via `FileVersionInfo.ProductVersion` on an `.exe`; here via `Get-MsiInformation` on the `.msi` since `Get-Command`'s `FileVersionInfo` doesn't apply to MSIs the same way).
- Added an explicit `throw` if the extracted version comes back empty/whitespace, so the update fails loudly instead of producing an "Invalid version" package.
- `au_SearchReplace`, checksum handling (`-ChecksumFor all`), and `au_AfterUpdate` (`Set-DescriptionFromReadme`) are unchanged.

## Scope

Only `automatic/speedtest-by-ookla/update.ps1` touched. No other packages affected.

**Not run in CI yet — needs Windows/AppVeyor (COM `WindowsInstaller.Installer` via `Get-MsiInformation` isn't testable on Linux). Please have a developer review and let CI run before merging.**