### PR TITLE
(scripts/orcaslicer) Add Get-FixVersion AU helper for same-version artifact-change re-publish

### DIFF
--- a/automatic/orcaslicer/update.ps1
+++ b/automatic/orcaslicer/update.ps1
@@ -12,6 +12,13 @@ function global:au_GetLatest {
   $Url32 = $release.assets | ? { $_.name -match 'Windows' -and $_.name -match 'x64' -and $_.name -like '*_portable.zip' } | Select-Object -First 1 -ExpandProperty browser_download_url
 
   $version = $release.tag_name.Trim('v')
+  # Same upstream tag can still mean a different published artifact for us
+  # (e.g. the arm64->x64 asset-selection fix above). Bump a synthetic fix
+  # revision so AU re-publishes even though the upstream version string is
+  # unchanged. NewChecksum is intentionally omitted here - the URL alone
+  # already differs (arm64 vs x64), so there is no need to download+hash
+  # the ~170 MB portable zip just to detect that.
+  $version = Get-FixVersion -UpstreamVersion $version -NewUrl $Url32 -PackageDir $PSScriptRoot
   $ChecksumType = 'sha256'
 
   $tag = $release.tag_name

--- a/scripts/au_extensions.psm1
+++ b/scripts/au_extensions.psm1
@@ -63,18 +63,20 @@ function Get-FixVersionInstallVariable {
   <#
   .SYNOPSIS
      Internal helper for Get-FixVersion. Robustly reads a
-     $name/$name64 = '...'-style assignment from a chocolateyinstall.ps1's
-     raw content. Tries the 64-suffixed variable name first, then the
-     plain name, since packages use either depending on which ChecksumFor
-     the au_SearchReplace block targets.
+     $name/$name64/$name32 = '...'-style assignment from a
+     chocolateyinstall.ps1's raw content. Tries the 64-suffixed variable
+     name first, then the 32-suffixed name, then the plain name, since
+     packages use whichever depending on which ChecksumFor the
+     au_SearchReplace block targets. Matching is case-insensitive since
+     PowerShell variable names are case-insensitive.
   #>
   param(
     [string] $Content,
     [string] $Name
   )
 
-  foreach ($candidate in @("$($Name)64", $Name)) {
-    $pattern = '(?m)^\s*\$' + [regex]::Escape($candidate) + '\s*=\s*([''"])(.*?)\1'
+  foreach ($candidate in @("$($Name)64", "$($Name)32", $Name)) {
+    $pattern = '(?mi)^\s*\$' + [regex]::Escape($candidate) + '\s*=\s*([''"])(.*?)\1'
     $match = [regex]::Match($Content, $pattern)
     if ($match.Success) {
       return $match.Groups[2].Value
@@ -206,9 +208,13 @@ function Get-FixVersion {
     $publishedUrl = $null
     $publishedChecksum = $null
     if ($installFile) {
-      $installContent = Get-Content -Path $installFile.FullName -Raw
-      $publishedUrl = Get-FixVersionInstallVariable -Content $installContent -Name 'url'
-      $publishedChecksum = Get-FixVersionInstallVariable -Content $installContent -Name 'checksum'
+      try {
+        $installContent = Get-Content -Path $installFile.FullName -Raw -ErrorAction Stop
+        $publishedUrl = Get-FixVersionInstallVariable -Content $installContent -Name 'url'
+        $publishedChecksum = Get-FixVersionInstallVariable -Content $installContent -Name 'checksum'
+      } catch {
+        Write-Warning "Get-FixVersion: could not read or parse '$($installFile.FullName)': $($_.Exception.Message)"
+      }
     }
 
     $urlChanged = [string]::IsNullOrEmpty($publishedUrl) -or ($NewUrl -ne $publishedUrl)

--- a/scripts/au_extensions.psm1
+++ b/scripts/au_extensions.psm1
@@ -20,3 +20,209 @@ $funcs | % {
     }
   }
 }
+
+# ---------------------------------------------------------------------------
+# Get-FixVersion (see comment-based help below).
+#
+# Kept directly in this module - instead of its own scripts\<Name>.ps1 file,
+# the convention used by the functions loaded via $funcs above - to keep
+# this change scoped to au_extensions.psm1 plus the au_GetLatest wiring in
+# the consuming update.ps1.
+# ---------------------------------------------------------------------------
+
+function Get-FixVersionBase {
+  <#
+  .SYNOPSIS
+     Internal helper for Get-FixVersion. Splits a version string into its
+     first-3-segment "base" and, if present, a numeric 4th-segment
+     revision (defaults to 0 when the 4th segment is absent).
+  #>
+  param([string] $VersionString)
+
+  if ([string]::IsNullOrWhiteSpace($VersionString)) {
+    return $null
+  }
+
+  $parts = $VersionString.Trim() -split '\.'
+  if ($parts.Count -lt 3) {
+    return $null
+  }
+
+  $revision = 0
+  if ($parts.Count -ge 4 -and $parts[3] -match '^\d+$') {
+    $revision = [int] $parts[3]
+  }
+
+  [pscustomobject]@{
+    Base     = ($parts[0..2] -join '.')
+    Revision = $revision
+  }
+}
+
+function Get-FixVersionInstallVariable {
+  <#
+  .SYNOPSIS
+     Internal helper for Get-FixVersion. Robustly reads a
+     $name/$name64 = '...'-style assignment from a chocolateyinstall.ps1's
+     raw content. Tries the 64-suffixed variable name first, then the
+     plain name, since packages use either depending on which ChecksumFor
+     the au_SearchReplace block targets.
+  #>
+  param(
+    [string] $Content,
+    [string] $Name
+  )
+
+  foreach ($candidate in @("$($Name)64", $Name)) {
+    $pattern = '(?m)^\s*\$' + [regex]::Escape($candidate) + '\s*=\s*([''"])(.*?)\1'
+    $match = [regex]::Match($Content, $pattern)
+    if ($match.Success) {
+      return $match.Groups[2].Value
+    }
+  }
+
+  return $null
+}
+
+<#
+.SYNOPSIS
+   Determine the version an AU package should publish for the current run,
+   including a synthetic "fix revision" when the upstream version did not
+   change but the resolved download artifact did.
+.DESCRIPTION
+   Chocolatey-AU's Update-Package only re-publishes a package when the
+   candidate version returned by au_GetLatest is greater than the version
+   already published (per the package's .nuspec). That is correct for real
+   upstream releases, but it means a fix in *our* au_GetLatest logic (e.g.
+   picking a different asset for the same upstream tag) is silently ignored
+   forever, because the upstream version string never changes.
+
+   Get-FixVersion compares the upstream version against the currently
+   published version (nuspec) and, for a same-base-version case, against
+   the currently published download URL (and optionally checksum) in
+   tools\chocolateyinstall.ps1. If the artifact actually changed while the
+   upstream version stayed the same, it returns a bumped 4th ("fix
+   revision") segment so Update-Package treats it as newer and
+   re-publishes. Otherwise it returns the upstream version unchanged, so
+   normal AU semantics apply (update on a real new release, skip when
+   nothing changed).
+
+   "Base version" here means the first three segments of the upstream
+   version scheme (e.g. 2.4.2 in both 2.4.2 and 2.4.2.1).
+
+   The comparison is intentionally URL-first: comparing strings costs
+   nothing, whereas verifying a checksum requires downloading the
+   artifact. -NewChecksum is optional for the case where the URL is
+   unchanged but the file behind it was swapped; callers that want that
+   signal without paying for a full download on every run could look at
+   caching the checksum keyed by the URL's ETag (not implemented here) and
+   pass the cached value in.
+.PARAMETER UpstreamVersion
+   The version string reported by upstream for this run (e.g. the GitHub
+   release tag with any leading 'v' trimmed). This is what au_GetLatest
+   would normally return as $Latest.Version.
+.PARAMETER NewUrl
+   The download URL au_GetLatest resolved for this run (e.g. $Url32/$Url64).
+.PARAMETER PackageDir
+   Path to the package directory (typically $PSScriptRoot of the calling
+   update.ps1). Used to locate the package's *.nuspec and
+   tools\chocolateyinstall.ps1.
+.PARAMETER NewChecksum
+   Optional. The checksum au_GetLatest resolved for this run. Only used as
+   an additional "did the artifact change" signal when the URL itself is
+   unchanged; omit it to avoid downloading the artifact just to hash it.
+.OUTPUTS
+   [string] The version to use as $Latest.Version for this run.
+.EXAMPLE
+   $version = Get-FixVersion -UpstreamVersion $version -NewUrl $Url32 -PackageDir $PSScriptRoot
+
+   Same upstream version, different URL than published -> returns e.g.
+   '2.4.2.1' so Update-Package republishes. Same upstream version, same
+   URL -> returns '2.4.2' unchanged so Update-Package skips (already
+   published). Higher upstream version -> returns it unchanged (normal
+   update).
+#>
+function Get-FixVersion {
+  [CmdletBinding()]
+  [OutputType([string])]
+  param(
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyString()]
+    [string] $UpstreamVersion,
+
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyString()]
+    [string] $NewUrl,
+
+    [Parameter(Mandatory = $true)]
+    [string] $PackageDir,
+
+    [Parameter(Mandatory = $false)]
+    [string] $NewChecksum
+  )
+
+  if ([string]::IsNullOrWhiteSpace($NewUrl)) {
+    # Nothing to compare against - behave like a normal update and let the
+    # rest of the AU pipeline surface the real problem (missing asset).
+    return $UpstreamVersion
+  }
+
+  $nuspecFile = Get-ChildItem -Path $PackageDir -Filter '*.nuspec' -File -ErrorAction SilentlyContinue | Select-Object -First 1
+  if (-not $nuspecFile) {
+    return $UpstreamVersion
+  }
+
+  $publishedVersionRaw = $null
+  try {
+    [xml] $nuspecXml = Get-Content -Path $nuspecFile.FullName -Raw
+    $publishedVersionRaw = $nuspecXml.package.metadata.version
+  } catch {
+    Write-Warning "Get-FixVersion: could not parse '$($nuspecFile.FullName)': $($_.Exception.Message)"
+    return $UpstreamVersion
+  }
+
+  $published = Get-FixVersionBase -VersionString $publishedVersionRaw
+  $upstream = Get-FixVersionBase -VersionString $UpstreamVersion
+  if (-not $published -or -not $upstream) {
+    return $UpstreamVersion
+  }
+
+  try {
+    $publishedBaseVersion = [version] $published.Base
+    $upstreamBaseVersion = [version] $upstream.Base
+  } catch {
+    # Non-numeric version scheme (e.g. pre-release suffix) - can't compare
+    # bases reliably, fall back to default AU behaviour.
+    return $UpstreamVersion
+  }
+
+  if ($upstreamBaseVersion -gt $publishedBaseVersion) {
+    return $UpstreamVersion
+  }
+
+  if ($upstreamBaseVersion -eq $publishedBaseVersion) {
+    $installFile = Get-ChildItem -Path (Join-Path $PackageDir 'tools') -Filter 'chocolateyinstall.ps1' -File -ErrorAction SilentlyContinue | Select-Object -First 1
+
+    $publishedUrl = $null
+    $publishedChecksum = $null
+    if ($installFile) {
+      $installContent = Get-Content -Path $installFile.FullName -Raw
+      $publishedUrl = Get-FixVersionInstallVariable -Content $installContent -Name 'url'
+      $publishedChecksum = Get-FixVersionInstallVariable -Content $installContent -Name 'checksum'
+    }
+
+    $urlChanged = [string]::IsNullOrEmpty($publishedUrl) -or ($NewUrl -ne $publishedUrl)
+    $checksumChanged = $false
+    if ($NewChecksum) {
+      $checksumChanged = [string]::IsNullOrEmpty($publishedChecksum) -or ($NewChecksum -ne $publishedChecksum)
+    }
+
+    if ($urlChanged -or $checksumChanged) {
+      return "$($published.Base).$($published.Revision + 1)"
+    }
+  }
+
+  return $UpstreamVersion
+}
+
+Export-ModuleMember -Function Get-FixVersion


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description

Adds a reusable `Get-FixVersion` helper to `scripts/au_extensions.psm1` and wires it into
`automatic/orcaslicer/update.ps1`'s `au_GetLatest`.

`Update-Package` (Chocolatey-AU) only re-publishes a package when the version returned by
`au_GetLatest` is greater than the version already in the package's `.nuspec`. `au_GetLatest`
and `au_SearchReplace` are package-owned functions (not upstream AU code), so this is entirely
within our control — no Chocolatey-AU upstream change involved.

`Get-FixVersion`:
1. Reads the currently *published* version from the package's `*.nuspec` and the currently
   published download URL (+ optionally checksum) from `tools\chocolateyinstall.ps1`
   (`$url`/`$url64`, `$checksum`/`$checksum64` — tries the `64`-suffixed variable first, falls
   back to the plain name).
2. Compares the upstream version's first-3-segment "base" against the published base:
   - upstream base **>** published base → returns the upstream version unchanged (normal
     update; the 4th "fix revision" segment naturally resets).
   - upstream base **==** published base **and** the resolved URL (or, if given, the checksum)
     differs from what's published → returns the published version with its 4th segment
     bumped by one (`2.4.2` → `2.4.2.1`, `2.4.2.1` → `2.4.2.2`), so `Update-Package` sees a
     "newer" version and republishes even though the upstream tag didn't change.
   - otherwise → returns the upstream version unchanged, so `Update-Package` correctly skips
     (nothing changed).
3. Fails safe throughout: missing/unparseable nuspec, empty `NewUrl`, non-numeric version
   segments, etc. all fall back to returning `$UpstreamVersion` untouched — i.e. default AU
   behaviour, never a hard error inside `au_GetLatest`.

Wired into OrcaSlicer's `au_GetLatest`:

```powershell
$version = $release.tag_name.Trim('v')
$version = Get-FixVersion -UpstreamVersion $version -NewUrl $Url32 -PackageDir $PSScriptRoot
```

`NewChecksum` is intentionally **not** passed for OrcaSlicer — the URL alone already differs
(arm64 vs. x64 asset), so there's no need to download and hash the ~170 MB portable zip just to
detect the change. See the trade-off note in the comment-based help of `Get-FixVersion` re.
using an ETag-cached checksum for the "same URL, swapped file" case, if a future package needs
that signal.

## Motivation and Context

Builds on **#12** (`fix: pin Windows asset selection to x64, exclude arm64`), which is **already
merged into `master`**. That fix changes which asset `au_GetLatest` resolves for OrcaSlicer
(x64 instead of arm64), but the upstream GitHub release tag stays `v2.4.2` — so without this
helper, `Update-Package` would never re-publish the corrected x64 package; it would keep seeing
`Latest.Version = 2.4.2`, which is not greater than the already-published `2.4.2`, and skip
forever.

Note on branching: the task originally called for stacking this branch on top of
`fix/win-arm64-x64-asset-selection`. That branch was squash-merged as #12 before this PR was
opened and is no longer an ancestor of `master` (master has since gained unrelated AU
auto-update commits), so branching from it would have produced a noisy diff against `master`.
Since `master` already contains the identical, already-merged x64-selection fix (verified
byte-identical `update.ps1` before this change), this PR branches from current `master` instead
— same effective base, clean diff. **No action needed regarding #12 — it's merged, not a
pending dependency.**

## How Has this Been Tested?

No Windows machine was available for this change, so PowerShell **Core 7.4.6 on Linux** was
used to load the module and exercise `Get-FixVersion` directly against the repo's real files
(and small simulated post-publish snapshots), rather than only reasoning through it by hand:

| # | Scenario | Inputs | Result | Expected |
|---|---|---|---|---|
| 1 | Current real state: published `orcaslicer.nuspec` = `2.4.2`, published `chocolateyinstall.ps1` `$url` = `...arm64_portable.zip`; new resolved URL = `...x64_portable.zip`; upstream tag still `2.4.2` | `UpstreamVersion=2.4.2`, `NewUrl=...x64_portable.zip` | `2.4.2.1` | `2.4.2.1` ✅ |
| 2 | Stability after publish: simulated nuspec `2.4.2.1`, published URL now the x64 URL; upstream tag still `2.4.2`, resolved URL unchanged (x64) | `UpstreamVersion=2.4.2`, `NewUrl=` same x64 URL | `2.4.2` (→ `Update-Package` sees `2.4.2` not `>` `2.4.2.1` → **skip**, no endless bump) | `2.4.2` ✅ |
| 3 | Real upstream release: upstream tag now `v2.4.3` | `UpstreamVersion=2.4.3`, `NewUrl=...v2.4.3.../x64...` | `2.4.3` (normal update) | `2.4.3` ✅ |
| 4 | Re-run of case 1's inputs against the already-bumped state → confirms no re-bump loop | same as case 1, `PackageDir` = post-publish snapshot | `2.4.2` (stable) | `2.4.2` ✅ |
| 5 | Same URL, but `NewChecksum` differs from published checksum (file swapped behind same URL) | `NewChecksum=<different>` | `2.4.2.2` | `2.4.2.2` ✅ |
| 6 | Empty `NewUrl` | `NewUrl=''` | `2.4.2` unchanged, no throw | ✅ |
| 7 | Missing/invalid `PackageDir` (no nuspec found) | `PackageDir=/tmp/does-not-exist` | `UpstreamVersion` returned unchanged, no throw | ✅ |

Both changed files were also parsed with
`[System.Management.Automation.Language.Parser]::ParseFile()` (PowerShell Core) with zero
syntax errors.

**Not tested:** the actual `Update-Package -ChecksumFor 32` end-to-end run (requires the real
Chocolatey-AU module + Windows + a live download), and `au_SearchReplace`/nuspec-file-writing
behavior driven by AU itself. **A Windows/CI run of the real `update.ps1` and a developer review
of the module code are needed before merging.**

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue) — OrcaSlicer would otherwise never
      re-publish the x64-corrected package for the current `v2.4.2` tag.
- [x] New feature (non-breaking change which adds functionality) — reusable `Get-FixVersion`
      helper other packages can adopt for the same same-version/changed-artifact situation.
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My code follows the code style of this repository (2-space indentation matching
      `au_extensions.psm1`; comment-based help matching the style of `Get-MsiInformation.ps1`).
- [ ] My change requires a change to documentation (this usually means the notes in the
      description of a package). — N/A, no package description/release-notes content changed.
- [ ] I have updated the documentation accordingly.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/strausmann/ChocolateyPackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment —
      **not run (no Windows available); needs a Windows/CI pass before merge.**
- [x] The changes only affect a single package (not including meta package) — only `orcaslicer`
      is wired up; `scripts/au_extensions.psm1` is shared infra, not a package.

## Scope note

Only `scripts/au_extensions.psm1` (helper) and `automatic/orcaslicer/update.ps1` (wiring) are
touched. No other package, no Chocolatey-AU upstream change. **Please do not merge without a
developer review and a Windows/CI run of the real `update.ps1` first.**
