### PR TITLE
feat(pangolin.newt): Pangolin Newt connector (optional Windows service)

### DIFF
--- a/automatic/pangolin.newt/README.md
+++ b/automatic/pangolin.newt/README.md
@@ -1,0 +1,11 @@
+# pangolin.newt
+
+Chocolatey package for [Newt](https://github.com/fosrl/newt), the site and network connector for [Pangolin](https://pangolin.net/).
+
+Optional Windows-service install via package parameters:
+
+    choco install pangolin.newt --params "/Id:<site-id> /Secret:<secret> /Endpoint:https://<host>"
+
+Without parameters only the `newt` binary is placed on the PATH. Automatically maintained (chocolatey-au) against fosrl/newt releases.
+
+Published as `pangolin.newt` because the `newt` id on the Community Repository is an unrelated legacy tool.

--- a/automatic/pangolin.newt/pangolin.newt.nuspec
+++ b/automatic/pangolin.newt/pangolin.newt.nuspec
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>pangolin.newt</id>
+    <version>1.14.0</version>
+    <owners>strausmann</owners>
+    <title>Pangolin Newt (Connector)</title>
+    <authors>fosrl</authors>
+    <projectUrl>https://pangolin.net/</projectUrl>
+    <projectSourceUrl>https://github.com/fosrl/newt</projectSourceUrl>
+    <packageSourceUrl>https://github.com/strausmann/ChocolateyPackages/tree/master/automatic/pangolin.newt</packageSourceUrl>
+    <bugTrackerUrl>https://github.com/fosrl/newt/issues</bugTrackerUrl>
+    <docsUrl>https://docs.pangolin.net/manage/sites/install-site</docsUrl>
+    <licenseUrl>https://github.com/fosrl/newt/blob/main/LICENSE</licenseUrl>
+    <releaseNotes>https://github.com/fosrl/newt/releases</releaseNotes>
+    <copyright>© 2026 Fossorial, Inc</copyright>
+    <iconUrl>https://cdn.jsdelivr.net/gh/strausmann/ChocolateyPackages@502da828ff77bbc4ace5cb8f2683a47ce9858719/icons/pangolin.png</iconUrl>
+    <tags>pangolin newt vpn wireguard zero-trust proxy remote-access ztna connector tunnel service</tags>
+    <summary>Newt — the site and network connector for Pangolin (WireGuard-based zero-trust remote access)</summary>
+    <description>Newt is the official site and network connector for [Pangolin](https://pangolin.net/) — an identity-aware, self-hostable tunneled reverse proxy and mesh VPN built on WireGuard.
+
+Newt runs on a machine inside a private network and establishes an outbound WireGuard tunnel to a Pangolin server, exposing local sites and services for zero-trust (ZTNA) remote access without opening inbound firewall ports.
+
+This package installs the official Windows `newt` binary from the [fosrl/newt](https://github.com/fosrl/newt) GitHub releases and puts it on the PATH as `newt`.
+
+## Optional Windows service
+
+Pass connection parameters and the package will register and start Newt as the **"Newt WireGuard Tunnel Service"**:
+
+    choco install pangolin.newt --params "/Id:<site-id> /Secret:<secret> /Endpoint:https://<pangolin-host>"
+
+Without parameters only the binary is placed on the system — set up the service yourself:
+
+    newt install
+    newt start --id <site-id> --secret <secret> --endpoint https://<pangolin-host>
+
+The service credentials are persisted by Newt itself to `%PROGRAMDATA%\newt\service_args.json`.
+
+## Package id note
+
+The plain `newt` id on the Community Repository belongs to an unrelated legacy tool, so this Pangolin connector is published as `pangolin.newt`. The installed command is still `newt`.
+
+Not affiliated with or endorsed by Fossorial, Inc.</description>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/automatic/pangolin.newt/tools/chocolateyBeforeModify.ps1
+++ b/automatic/pangolin.newt/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,11 @@
+﻿$ErrorActionPreference = 'Continue';
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$exe = Join-Path $toolsDir 'newt.exe'
+
+# Laeuft vor Upgrade UND Uninstall: Dienst best-effort stoppen + entfernen,
+# damit die exe fuer Upgrades entsperrt ist und kein verwaister Dienst zurueckbleibt.
+# Fehler ignorieren (z.B. wenn nie ein Dienst eingerichtet wurde).
+if (Test-Path $exe) {
+  try { & $exe stop   2>$null | Out-Null } catch { }
+  try { & $exe remove 2>$null | Out-Null } catch { }
+}

--- a/automatic/pangolin.newt/tools/chocolateyinstall.ps1
+++ b/automatic/pangolin.newt/tools/chocolateyinstall.ps1
@@ -1,0 +1,44 @@
+﻿$ErrorActionPreference = 'Stop';
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$url64      = 'https://github.com/fosrl/newt/releases/download/1.14.0/newt_windows_amd64.exe'
+$checksum64 = '1cc00dfcebd77544c8a29d6acd0771b7080f4ee43e2ff1bfac0f57285f097c06'
+
+$exe = Join-Path $toolsDir 'newt.exe'
+$packageArgs = @{
+  packageName    = $env:ChocolateyPackageName
+  fileFullPath   = $exe
+  url64bit       = $url64
+  checksum64     = $checksum64
+  checksumType64 = 'sha256'
+}
+Get-ChocolateyWebFile @packageArgs
+
+# Optionaler Windows-Dienst: nur wenn Id + Secret + Endpoint uebergeben wurden
+$pp       = Get-PackageParameters
+$id       = $pp['Id']
+$secret   = $pp['Secret']
+$endpoint = $pp['Endpoint']
+
+if ($id -and $secret -and $endpoint) {
+  Write-Host "Registriere Newt als Windows-Dienst 'Newt WireGuard Tunnel Service'..."
+  & $exe install
+  # 'newt start' persistiert die Credentials nach %PROGRAMDATA%\newt\service_args.json
+  # und startet den Dienst damit. (Secret liegt danach dort im Klartext - by design.)
+  & $exe start --id $id --secret $secret --endpoint $endpoint
+  Write-Host "Newt-Dienst installiert und gestartet."
+} else {
+  Write-Host @"
+
+newt.exe wurde installiert und ist als 'newt' im PATH verfuegbar.
+Es wurde KEIN Windows-Dienst eingerichtet (keine /Id /Secret /Endpoint uebergeben).
+
+Dienst manuell einrichten:
+  newt install
+  newt start --id <SITE_ID> --secret <SECRET> --endpoint https://<pangolin-host>
+
+Oder mit Parametern neu installieren:
+  choco install pangolin.newt --params "/Id:<id> /Secret:<secret> /Endpoint:https://<host>"
+
+"@
+}

--- a/automatic/pangolin.newt/update.ps1
+++ b/automatic/pangolin.newt/update.ps1
@@ -1,0 +1,30 @@
+Import-Module Chocolatey-AU
+Import-Module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
+
+$release = Get-GitHubRelease fosrl newt
+
+function global:au_GetLatest {
+  $version = $release.tag_name
+  $asset = $release.assets | Where-Object { $_.name -match 'newt_windows_amd64\.exe' } | Select-Object -First 1
+  $Url64 = $asset.browser_download_url
+
+  return @{
+    Version = $version
+    Url64   = $Url64
+  }
+}
+
+function global:au_BeforeUpdate {
+  $Latest.Checksum64 = Get-RemoteChecksum $Latest.Url64 -Algorithm 'sha256'
+}
+
+function global:au_SearchReplace {
+  @{
+    'tools\chocolateyInstall.ps1' = @{
+      "(?i)(^`$url64\s*=\s*)'.*'"      = "`${1}'$($Latest.Url64)'"
+      "(?i)(^`$checksum64\s*=\s*)'.*'" = "`${1}'$($Latest.Checksum64)'"
+    }
+  }
+}
+
+Update-Package -ChecksumFor none


### PR DESCRIPTION
Neues Package `pangolin.newt` fuer den [Newt](https://github.com/fosrl/newt)-Connector.

**Installiert:** portable `newt.exe` (1.14.0) in den PATH als `newt`.

**Optionaler Windows-Dienst** (nur mit Parametern):
```
choco install pangolin.newt --params "/Id:<site-id> /Secret:<secret> /Endpoint:https://<host>"
```
-> `newt install` + `newt start --id/--secret/--endpoint` (Dienst *Newt WireGuard Tunnel Service*; Creds persistiert Newt selbst nach `%PROGRAMDATA%\newt\service_args.json`).
Ohne Parameter: nur Binary platzieren, User richtet den Dienst selbst ein.

**Teardown:** `chocolateyBeforeModify.ps1` (laeuft vor Upgrade+Uninstall) stoppt+entfernt den Dienst best-effort; Binary+Shim raeumt Chocolatey automatisch -> **keine** `chocolateyuninstall.ps1` noetig.

**ID-Wahl:** `newt` ist auf dem Community-Repo ein fremdes Legacy-Tool -> dot-ID `pangolin.newt` (wie `pangolin.cli`).

Auto-Update via chocolatey-au. Nach Merge: `[PUSH pangolin.newt]`-Commit triggert den ersten Push (neue ID -> kein 403 erwartet). Nicht gemergt, Review zuerst.