### PR TITLE
fix(qemu-virtio-driver): register + start VirtIO Balloon service (Issue #11)

### DIFF
--- a/automatic/qemu-virtio-driver/qemu-virtio-driver.nuspec
+++ b/automatic/qemu-virtio-driver/qemu-virtio-driver.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>qemu-virtio-driver</id>
-    <version>0.1.285</version>
+    <version>0.1.285.1</version>
     <owners>Bjoern Strausmann</owners>
     <title>Virtio Win Driver (Install)</title>
     <authors>Red Hat Inc.</authors>
@@ -57,7 +57,7 @@ To use choco:// protocol URLs, install [(unofficial) choco:// Protocol support](
 ---
 
 **Please Note**: This is an automatically updated package. If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
-</description>
+ This package also registers and starts the VirtIO Balloon service (blnsvr) so guest memory stats and dynamic ballooning work (e.g. on Proxmox).</description>
     <releaseNotes>https://fedorapeople.org/groups/virt/virtio-win/CHANGELOG</releaseNotes>
   </metadata>
   <files>

--- a/automatic/qemu-virtio-driver/tools/chocolateyBeforeModify.ps1
+++ b/automatic/qemu-virtio-driver/tools/chocolateyBeforeModify.ps1
@@ -4,6 +4,9 @@
 # Service wieder entfernen, solange blnsvr.exe noch existiert (MSI-Uninstall raeumt
 # die Dateien erst danach). Best-effort.
 if (Get-Service -Name 'BalloonService' -ErrorAction SilentlyContinue) {
-  $blnsvr = Get-ChildItem -Path (Join-Path $env:ProgramFiles 'Virtio-Win\Balloon') -Recurse -Filter 'blnsvr.exe' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $blnsvr = @($env:ProgramW6432, $env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ } | Select-Object -Unique |
+    ForEach-Object { Join-Path $_ 'Virtio-Win\Balloon' } | Where-Object { Test-Path $_ } |
+    ForEach-Object { Get-ChildItem -Path $_ -Recurse -Filter 'blnsvr.exe' -ErrorAction SilentlyContinue } |
+    Select-Object -First 1
   if ($blnsvr) { try { & $blnsvr.FullName '-u' } catch { } }
 }

--- a/automatic/qemu-virtio-driver/tools/chocolateyBeforeModify.ps1
+++ b/automatic/qemu-virtio-driver/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,9 @@
+﻿$ErrorActionPreference = 'Continue';
+
+# Vor Upgrade/Uninstall (Issue #11): den bei Install registrierten VirtIO Balloon
+# Service wieder entfernen, solange blnsvr.exe noch existiert (MSI-Uninstall raeumt
+# die Dateien erst danach). Best-effort.
+if (Get-Service -Name 'BalloonService' -ErrorAction SilentlyContinue) {
+  $blnsvr = Get-ChildItem -Path (Join-Path $env:ProgramFiles 'Virtio-Win\Balloon') -Recurse -Filter 'blnsvr.exe' -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($blnsvr) { try { & $blnsvr.FullName '-u' } catch { } }
+}

--- a/automatic/qemu-virtio-driver/tools/chocolateyinstall.ps1
+++ b/automatic/qemu-virtio-driver/tools/chocolateyinstall.ps1
@@ -22,3 +22,23 @@ $packageArgs = @{
 }
 
 Install-ChocolateyPackage @packageArgs
+# --- VirtIO Balloon Service (Issue #11) ---
+# Die virtio-win-gt MSI installiert blnsvr.exe, registriert den Dienst 'BalloonService'
+# aber nicht -> ohne ihn liefert der Gast keine Memory-Stats / kein dynamisches
+# Ballooning (z.B. Proxmox). Idempotent: nur registrieren, wenn der Dienst noch fehlt.
+if (-not (Get-Service -Name 'BalloonService' -ErrorAction SilentlyContinue)) {
+  $blnsvr = Get-ChildItem -Path (Join-Path $env:ProgramFiles 'Virtio-Win\Balloon') -Recurse -Filter 'blnsvr.exe' -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($blnsvr) {
+    Write-Host "Registering VirtIO Balloon Service: $($blnsvr.FullName) -i"
+    & $blnsvr.FullName '-i'
+  } else {
+    Write-Warning "blnsvr.exe not found under '$env:ProgramFiles\Virtio-Win\Balloon' - Balloon service not registered."
+  }
+}
+
+# InstallService setzt Auto-Start, startet aber nicht zwingend sofort -> sicher starten.
+$balloonSvc = Get-Service -Name 'BalloonService' -ErrorAction SilentlyContinue
+if ($balloonSvc -and $balloonSvc.Status -ne 'Running') {
+  try { Start-Service -Name 'BalloonService' -ErrorAction Stop }
+  catch { Write-Warning "Could not start BalloonService: $($_.Exception.Message)" }
+}

--- a/automatic/qemu-virtio-driver/tools/chocolateyinstall.ps1
+++ b/automatic/qemu-virtio-driver/tools/chocolateyinstall.ps1
@@ -27,7 +27,10 @@ Install-ChocolateyPackage @packageArgs
 # aber nicht -> ohne ihn liefert der Gast keine Memory-Stats / kein dynamisches
 # Ballooning (z.B. Proxmox). Idempotent: nur registrieren, wenn der Dienst noch fehlt.
 if (-not (Get-Service -Name 'BalloonService' -ErrorAction SilentlyContinue)) {
-  $blnsvr = Get-ChildItem -Path (Join-Path $env:ProgramFiles 'Virtio-Win\Balloon') -Recurse -Filter 'blnsvr.exe' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $blnsvr = @($env:ProgramW6432, $env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ } | Select-Object -Unique |
+    ForEach-Object { Join-Path $_ 'Virtio-Win\Balloon' } | Where-Object { Test-Path $_ } |
+    ForEach-Object { Get-ChildItem -Path $_ -Recurse -Filter 'blnsvr.exe' -ErrorAction SilentlyContinue } |
+    Select-Object -First 1
   if ($blnsvr) {
     Write-Host "Registering VirtIO Balloon Service: $($blnsvr.FullName) -i"
     & $blnsvr.FullName '-i'


### PR DESCRIPTION
Behebt den offenen Rest aus Issue #11 (@stumbaumr): der VirtIO **Balloon-Service** wird nicht gestartet -> kein dynamisches Memory-Ballooning (Proxmox).

**Verifiziert (nicht geraten):**
- `kvm-guest-drivers-windows` `Balloon/app/main.cpp`: `ServiceName = "BalloonService"`, `-i`=InstallService, `-u`=UninstallService
- MSI `virtio-win-gt-x64.msi` enthaelt `blnsvr`-Binaries (w10/w11/2k16-2k25), Install-Pfad `%ProgramFiles%\Virtio-Win\Balloon\...`
- Referenz `DDoSolitary/chocolatey-packages` ruft ebenfalls `blnsvr.exe -i` / `-u` auf

**Aenderungen:**
- `chocolateyinstall.ps1`: idempotentes `blnsvr.exe -i` (nur wenn `BalloonService` fehlt) + Dienst starten
- `chocolateyBeforeModify.ps1` (neu): `blnsvr.exe -u` vor Upgrade/Uninstall
- Version `0.1.285.1` (Fix-Revision; `0.1.285` ist bereits published)

Idempotent: falls die MSK den Dienst kuenftig doch selbst registriert, wird `-i` uebersprungen. Nach Merge: `[PUSH qemu-virtio-driver]`. Refs #11