### PR TITLE
chore(renovate): auto-update AppVeyor CI tool pins (vt-cli, chocolatey-au, ...) via custom manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,32 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
   ],
-  "assignees": ["virtualex-itv"],
+  "assignees": ["strausmann"],
   "labels": ["renovate"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "AppVeyor CI-Tool-Pins (chocolatey-au, vt-cli, wormies-au-helpers, git, ...) gegen den Chocolatey-Feed aktualisieren",
+      "fileMatch": ["^\\.appveyor\\.yml$"],
+      "matchStrings": [
+        "'(?<depName>[A-Za-z0-9._-]+)'\\s*=\\s*'(?<currentValue>[0-9][0-9A-Za-z.-]*)'"
+      ],
+      "datasourceTemplate": "nuget",
+      "registryUrlTemplate": "https://community.chocolatey.org/api/v2/"
+    }
+  ],
   "packageRules": [
-  {
-    "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-    "automerge": true
-  }
- ]
+    {
+      "description": "Risikoarme Updates automergen (bestehendes Verhalten)",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Build-kritische CI-Tool-Pins aus .appveyor.yml: nur PR zur Review, KEIN Automerge",
+      "matchFileNames": [".appveyor.yml"],
+      "automerge": false
+    }
+  ]
 }


### PR DESCRIPTION
**Ziel:** die veralteten CI-Tool-Pins in `.appveyor.yml` automatisch aktuell halten (Ausloeser: `vt-cli` haengt bei `1.2.0`, aktuell ist `1.3.1`).

**Warum Renovate statt Dependabot:** Dependabot hat kein Chocolatey-Oekosystem und kann keine `'name' = 'version'`-Strings in `.appveyor.yml` parsen; es gibt auch keinen GitHub-Actions-Workflow. Renovate ist schon konfiguriert (`renovate.json`) und kann es via **customManager (Regex)** gegen den Chocolatey/NuGet-Feed.

**Aenderungen:**
- `customManager`: matcht die Tool-Pins (chocolatey-au, vt-cli, wormies-au-helpers, autohotkey.portable, git, chocolatey-core/-compatibility.extension) -> Update-PRs gegen `community.chocolatey.org/api/v2/`.
- `assignees`: `virtualex-itv` (Fork-Ursprung) -> `strausmann`.
- CI-Pins: **PR zur Review**, kein Automerge (build-kritisch; ein kaputter chocolatey-au-Bump wuerde sonst alle Builds treffen).

**WICHTIG - noch zu tun (kann ich nicht):** Die **Renovate GitHub-App** muss auf `strausmann/ChocolateyPackages` installiert werden (github.com/apps/renovate). Aktuell laeuft Renovate nicht (keine renovate-Branches/PRs) - die `renovate.json` kam nur mit dem Fork mit.

Nicht gemergt, Review zuerst.